### PR TITLE
DB connection pool established

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "dotenv",
  "env_logger 0.8.3",
  "mysqlclient-sys",
+ "r2d2",
  "serde",
  "tera",
 ]
@@ -905,6 +906,7 @@ dependencies = [
  "chrono",
  "diesel_derives",
  "pq-sys",
+ "r2d2",
 ]
 
 [[package]]
@@ -1990,6 +1992,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,6 +2284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ actix-web = "3"
 actix-identity = "0.3.1"
 tera = "1"
 serde = "1.0"
-diesel = { version = "1.4.0", features = ["postgres", "chrono"] }
+diesel = { version = "1.4.4", features = ["postgres", "chrono", "r2d2"] }
 dotenv = "0.15.0"
 mysqlclient-sys = { version = ">=0.1.0, <0.3.0", optional = true }
 chrono = { version = "0.4", features = ["serde"] }
 argonautica = "0.2.0"
+r2d2 = "0.8"
 
 


### PR DESCRIPTION
Added out pool as a variable we pass into our index function. Made the type alias, had we not created a Pool type alias, we would have had to type out pool: web::Datar2d2::Pool<ConnectionManager<PgConnection>> everywhere.

Next, we change our connection variable from "establish_connection()" to "pool.get().unwrap()". With that we are done! We have connection pooling now set up.

We can no do the same thing for all of our establish_connection calls. We first add the pool variable to our function parameters and then we swap our the connection variable.

With that, we should see no visible difference in our website! but we'll know in our hearts that connection pooling is up and working!